### PR TITLE
Bound path generation work to prevent watchdog hangs and reduce tick spikes

### DIFF
--- a/src/main/java/com/amber/roads/TravelersConfig.java
+++ b/src/main/java/com/amber/roads/TravelersConfig.java
@@ -14,13 +14,31 @@ public class TravelersConfig
             .comment("How many chunks away from world center a path must be to spawn")
             .defineInRange("distanceFromWorldCenter", 7, 0, Integer.MAX_VALUE);
 
+    private static final ModConfigSpec.IntValue MAX_FIND_Y_STEPS = BUILDER
+            .comment("Maximum vertical checks while finding valid path surface Y before giving up")
+            .defineInRange("maxFindYSteps", 96, 1, Integer.MAX_VALUE);
+
+    private static final ModConfigSpec.IntValue MAX_SECTIONS_PER_TICK = BUILDER
+            .comment("Maximum number of path sections placed per build tick")
+            .defineInRange("maxSectionsPerTick", 2, 1, Integer.MAX_VALUE);
+
+    private static final ModConfigSpec.IntValue MAX_SECTION_PLACE_RETRIES = BUILDER
+            .comment("Maximum retries for placing the same path section before aborting that path")
+            .defineInRange("maxSectionPlaceRetries", 12, 1, Integer.MAX_VALUE);
+
     static final ModConfigSpec SPEC = BUILDER.build();
 
     public static int distanceFromWorldCenter;
+    public static int maxFindYSteps;
+    public static int maxSectionsPerTick;
+    public static int maxSectionPlaceRetries;
 
 
     @SubscribeEvent
     static void onLoad(final ModConfigEvent event) {
         distanceFromWorldCenter = DISTANCE_FROM_WORLD_CENTER.get();
+        maxFindYSteps = MAX_FIND_Y_STEPS.get();
+        maxSectionsPerTick = MAX_SECTIONS_PER_TICK.get();
+        maxSectionPlaceRetries = MAX_SECTION_PLACE_RETRIES.get();
     }
 }

--- a/src/main/java/com/amber/roads/world/TravelersPath.java
+++ b/src/main/java/com/amber/roads/world/TravelersPath.java
@@ -1,5 +1,6 @@
 package com.amber.roads.world;
 
+import com.amber.roads.TravelersConfig;
 import com.amber.roads.TravelersCrossroads;
 import com.amber.roads.util.TravelersDirection;
 import com.amber.roads.worldgen.TravelersFeatures;
@@ -24,6 +25,7 @@ public class TravelersPath {
     private boolean completed;
     private final ArrayList<PathNode> path;
     private int currentIndex;
+    private int failedPlacementRetries;
 
     public TravelersPath(
             RandomSource randomSource,
@@ -32,6 +34,7 @@ public class TravelersPath {
     ) {
         this.currentIndex = 0;
         this.completed = false;
+        this.failedPlacementRetries = 0;
         this.path = new ArrayList<>();
         this.path.add(startNode);
         this.pathStyle = pathStyle;
@@ -68,6 +71,7 @@ public class TravelersPath {
             this.path.add(new PathNode(pathData.getCompound(String.valueOf(i))));
         }
         this.currentIndex = data.getInt("currentIndex");
+        this.failedPlacementRetries = 0;
         if (data.contains("style")) {
             PathStyle.DIRECT_CODEC
                     .parse(new Dynamic<>( RegistryOps.create(NbtOps.INSTANCE, TravelersWatcher.server.registryAccess()), data.get("style")))
@@ -106,18 +110,33 @@ public class TravelersPath {
         return this.path.getLast();
     }
 
-    public void placeNextSection(ServerLevel level) {
+    public boolean placeNextSection(ServerLevel level) {
         // TravelersCrossroads.LOGGER.debug("Placing Section for Path: {} {}", path.getFirst(), path.getLast());
 
         if (this.currentIndex < this.path.size() - 1) {
-            this.currentIndex += this.pathStyle.placeSection(level, this.path.get(this.currentIndex), this.path.get(this.currentIndex + 1)) ? 1 : 0;
-            if (this.currentIndex % this.pathStyle.getNodeDistance() == 0 && this.path.size() - this.currentIndex > this.pathStyle.getNodeDistance()) {
-                TravelersWatcher.crossroadsData.addPathNode(this.path.get(this.currentIndex+1));
+            boolean placed = this.pathStyle.placeSection(level, this.path.get(this.currentIndex), this.path.get(this.currentIndex + 1));
+            if (placed) {
+                this.currentIndex += 1;
+                this.failedPlacementRetries = 0;
+                if (this.currentIndex % this.pathStyle.getNodeDistance() == 0 && this.path.size() - this.currentIndex > this.pathStyle.getNodeDistance()) {
+                    TravelersWatcher.crossroadsData.addPathNode(this.path.get(this.currentIndex+1));
+                }
+                return true;
+            }
+
+            this.failedPlacementRetries++;
+            if (this.failedPlacementRetries >= Math.max(1, TravelersConfig.maxSectionPlaceRetries)) {
+                TravelersCrossroads.LOGGER.debug(
+                        "Aborting stuck path section after {} retries. start={} end={} currentIndex={}",
+                        this.failedPlacementRetries, this.path.getFirst(), this.path.getLast(), this.currentIndex
+                );
+                this.completed = true;
             }
         } else {
             this.completed = true;
         }
 
+        return false;
     }
 
     public boolean completed() {

--- a/src/main/java/com/amber/roads/worldgen/TravelersWatcher.java
+++ b/src/main/java/com/amber/roads/worldgen/TravelersWatcher.java
@@ -1,5 +1,6 @@
 package com.amber.roads.worldgen;
 
+import com.amber.roads.TravelersConfig;
 import com.amber.roads.TravelersCrossroads;
 import com.amber.roads.init.TravelersRegistries;
 import com.amber.roads.util.CrossroadsData;
@@ -289,10 +290,17 @@ public class TravelersWatcher {
         }
 
         List<TravelersPath> paths = crossroadsData.getUnfinishedPaths();
+        int sectionsPlaced = 0;
+        int maxSectionsPerTick = Math.max(1, TravelersConfig.maxSectionsPerTick);
         for (TravelersPath path: paths) {
+            if (sectionsPlaced >= maxSectionsPerTick) {
+                break;
+            }
             if (!path.completed()) {
                 try {
-                    path.placeNextSection(server.overworld());
+                    if (path.placeNextSection(server.overworld())) {
+                        sectionsPlaced++;
+                    }
                 } catch (Exception e) {
                     System.out.println("path placement failed: ");
                     e.printStackTrace();

--- a/src/main/java/com/amber/roads/worldgen/custom/pathstyle/PathStyle.java
+++ b/src/main/java/com/amber/roads/worldgen/custom/pathstyle/PathStyle.java
@@ -1,5 +1,6 @@
 package com.amber.roads.worldgen.custom.pathstyle;
 
+import com.amber.roads.TravelersConfig;
 import com.amber.roads.TravelersCrossroads;
 import com.amber.roads.init.TravelersInit;
 import com.amber.roads.init.TravelersRegistries;
@@ -166,24 +167,35 @@ public abstract class PathStyle {
     public abstract void placeExtraBlocks(ServerLevel level, PathNode pos1, TravelersDirection direction, List<BlockPos> extraBlockPositions);
 
     public static Optional<BlockPos> findY(ServerLevel level, BlockPos origin) {
-
-        while (!level.getBlockState(origin.above()).is(PATH_ABOVE) || !level.getBlockState(origin).is(PATH_BELOW)) {
+        BlockPos current = origin;
+        final int minBuildHeight = level.getMinBuildHeight();
+        final int maxBuildHeight = level.getMaxBuildHeight();
+        final int maxSteps = Math.max(1, TravelersConfig.maxFindYSteps);
+        for (int steps = 0; steps < maxSteps; steps++) {
+            if (current.getY() <= minBuildHeight || current.getY() >= maxBuildHeight - 1) {
+                return Optional.empty();
+            }
+            var aboveState = level.getBlockState(current.above());
+            var currentState = level.getBlockState(current);
+            if (aboveState.is(PATH_ABOVE) && currentState.is(PATH_BELOW)) {
+                return Optional.of(current);
+            }
             /**TravelersCrossroads.LOGGER.debug(
                     "Blockstates: {} {}",
-                    level.getBlockState(origin.above()),
-                    level.getBlockState(origin)
+                    aboveState,
+                    currentState
             );*/
-            if (level.getBlockState(origin.above()).getFluidState().isSource() || level.getBlockState(origin).getFluidState().isSource()){
+            if (aboveState.getFluidState().isSource() || currentState.getFluidState().isSource()){
                 return Optional.empty();
-            } else if (level.getBlockState(origin).is(PATH_ABOVE)) {
-                origin = origin.below();
-            } else if (level.getBlockState(origin.above()).is(PATH_BELOW)) {
-                origin = origin.above();
+            } else if (currentState.is(PATH_ABOVE)) {
+                current = current.below();
+            } else if (aboveState.is(PATH_BELOW)) {
+                current = current.above();
             } else {
-                break;
+                return Optional.empty();
             }
         }
-        return Optional.of(origin);
+        return Optional.empty();
     }
 
     public int getDistance() {


### PR DESCRIPTION
This PR adds small, targeted bounds to path generation so road placement cannot run unbounded in a server tick.

This PR addresses issue #1

**Changes**

  1. Adds bounded vertical search in PathStyle.findY
       - Replaces unbounded loop with a max-iteration cap (maxFindYSteps) and build-height bounds checks.
       - Returns empty when no valid placement is found within that cap.

  2. Adds a retry cap for repeatedly failing sections in TravelersPath.java
       - Now tracks failed placement attempts
       - Aborts that path after maxSectionPlaceRetries to avoid infinite retry across ticks

  3. Adds a per-build-tick section budget in TravelersWatcher.buildPaths
       - Limits work to maxSectionsPerTick successful section placements per build pass.

  4. Add some config values in TravelersConfig, just for fine-tuning
       - maxFindYSteps (default: 96)
       - maxSectionsPerTick (default: 2)
       - maxSectionPlaceRetries (default: 12) 

Verified in-game during world generation and no watchdog hangs were observed in my tests.

Thank you again for your work! 